### PR TITLE
Update migrations to be DB independent

### DIFF
--- a/db/migrate/002_create_enum_prices.rb
+++ b/db/migrate/002_create_enum_prices.rb
@@ -4,8 +4,6 @@ class CreateEnumPrices < ActiveRecord::Migration
       t.references :enumerations
       t.float :price
     end
-    execute <<-SQL
-          ALTER TABLE `prices` ADD INDEX ( `enumerations_id` ) ;
-    SQL
+    add_index :prices, :enumerations_id
   end
 end


### PR DESCRIPTION
The previous syntax was mysql-only
