### PR TITLE
Fixing problem while executing in rails 3.2.19

### DIFF
--- a/app/controllers/timesheet_controller.rb
+++ b/app/controllers/timesheet_controller.rb
@@ -120,9 +120,9 @@ class TimesheetController < ApplicationController
 
   def allowed_projects
     if User.current.admin?
-      return Project.all.order('name ASC')
+      return Project.all.sort
     else
-      return Project.where(Project.visible_condition(User.current)).order('name ASC')
+      return Project.where(Project.visible_condition(User.current)).sort
     end
   end
 


### PR DESCRIPTION
Running the plugin under Redmine 2.6.0 and rails 3.2.19 I get the message 

undefined method `order' for #<Array:0x718c278>

With these changes, I have fixed the error