### PR TITLE
Init.rb - Fixed permissions definition and required redmine version

### DIFF
--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -326,11 +326,11 @@ class Timesheet
         # Administrators can see all time entries
         logs = time_entries_for_all_users(project)
         users = logs.collect(&:user).uniq.sort
-      elsif User.current.allowed_to_on_single_potentially_archived_project?(:see_project_timesheets, project)
+      elsif User.current.allowed_to?(:see_all_project_timesheets, nil, :global => true)
         # Users with the Role and correct permission can see all time entries
         logs = time_entries_for_all_users(project)
         users = logs.collect(&:user).uniq.sort
-      elsif User.current.allowed_to_on_single_potentially_archived_project?(:view_time_entries, project)
+      elsif User.current.allowed_to?(:view_time_entries, project)
         # Users with permission to see their time entries
         logs = time_entries_for_current_user(project)
         users = logs.collect(&:user).uniq.sort
@@ -382,7 +382,7 @@ class Timesheet
       elsif User.current.id == user_id
         # Users can see their own their time entries
         logs = time_entries_for_user(user_id)
-      elsif User.current.allowed_to_on_single_potentially_archived_project?(:see_project_timesheets, nil, :global => true)
+      elsif User.current.allowed_to?(:see_all_project_timesheets, nil, :global => true)
         # User can see project timesheets in at least once place, so
         # fetch the user timelogs for those projects
         logs = time_entries_for_user(user_id, :conditions => Project.allowed_to_condition(User.current, :see_project_timesheets))
@@ -414,7 +414,7 @@ class Timesheet
         if User.current.admin?
           # Administrators can see all time entries
           logs << issue_time_entries_for_all_users(issue)
-        elsif User.current.allowed_to_on_single_potentially_archived_project?(:see_project_timesheets, project)
+        elsif User.current.allowed_to?(:see_all_project_timesheets, nil, :global => true)
           # Users with the Role and correct permission can see all time entries
           logs << issue_time_entries_for_all_users(issue)
         elsif User.current.allowed_to_on_single_potentially_archived_project?(:view_time_entries, project)

--- a/init.rb
+++ b/init.rb
@@ -41,7 +41,7 @@ unless Redmine::Plugin.registered_plugins.keys.include?(:redmine_timesheet_plugi
     author_url 'https://github.com/arkhitech'
 
     version '0.7.0'
-    requires_redmine :version_or_higher => '0.9.0'
+    requires_redmine :version_or_higher => '2.0.0'
     
     settings(:default => {
                'list_size' => '5',
@@ -50,8 +50,10 @@ unless Redmine::Plugin.registered_plugins.keys.include?(:redmine_timesheet_plugi
                'user_status' => 'active'
              }, :partial => 'settings/timesheet_settings')
 
-    permission :see_project_timesheets, { }, :require => :member
-    permission :see_all_project_timesheets, { }, :require => :member
+    project_module :timesheet do
+	permission :see_project_timesheets, {}
+	permission :see_all_project_timesheets, {}
+    end
 
     menu(:top_menu,
          :timesheet,


### PR DESCRIPTION
The permission definition in init.rb was not working for Redmine 2.x.

Also the required version of redmine was wrong.