### PR TITLE
fix different types of keys in time_series hash

### DIFF
--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -373,7 +373,7 @@ class Timesheet
       # Append the parent project name
       if project.parent.nil?
         unless logs.empty?
-          self.time_entries[project] = { :logs => logs, :users => users }
+          self.time_entries[project.to_s] = { :logs => logs, :users => users }
         end
       else
         unless logs.empty?


### PR DESCRIPTION
In e70694b56c0eb0bdd27ba5518a130eb19f9bba95 the keys for the
time_entries hash of the Timesheet class were changed to project objects
instead of strings. In 7a207d4e4cb305ec2b5788bd7f18e68043365615 this was
changed to strings again, but only for non-top-level projects, which
results in different types of keys for this hash. This breaks if entries
for top-level and non-top-level projects are mixed in a Timesheet and
sort is called on the time_entries hash since the compare method of
Redmine's class "project" doesn't support handling of objects of other
types.

This commit adds conversion to string for the key for top-level projects
so the type of the keys is uniform.