### PR TITLE
Minor fixes to make plugin compatible with Redmine 3.4:

### DIFF
--- a/app/views/timesheet/_form.html.erb
+++ b/app/views/timesheet/_form.html.erb
@@ -15,9 +15,9 @@
           <label for="timesheet_date_from"><%= l(:timesheet_date_from_label)%></label>
         </div>
         <span id="select_timesheet_period_type_2" onclick="$('#timesheet_period_type_2').checked = true;">
-          <%= f.text_field "date_from", :size => 10 %><%= calendar_for('timesheet_date_from') %>
+          <%= f.date_field "date_from", :size => 10 %><%= calendar_for('timesheet_date_from') %>
           <label for="timesheet_date_to"><%= l(:timesheet_date_to_label)%></label>
-          <%= f.text_field "date_to", :size => 10 %><%= calendar_for('timesheet_date_to') %>
+          <%= f.date_field "date_to", :size => 10 %><%= calendar_for('timesheet_date_to') %>
         </span>
       </div>
       

--- a/app/views/timesheet/report.html.erb
+++ b/app/views/timesheet/report.html.erb
@@ -55,7 +55,7 @@
   <%= call_hook(:plugin_timesheet_views_timesheets_report_header_tags, { :timesheet => @timesheet }) %>
 <% end %>
 
-<%= context_menu time_entries_context_menu_path %>
+<%= context_menu %>
 
 <%# TODO: Typo on hook %>
 <%= call_hook(:plugin_timesheet_view_timesheets_report_bottom, { :timesheet => @timesheet }) %>


### PR DESCRIPTION
- context_menu no longer takes arguments (compare https://github.com/redmine/redmine/blob/3.3-stable/app/helpers/application_helper.rb#L1157 and https://github.com/redmine/redmine/blob/3.4-stable/app/helpers/application_helper.rb#L1300 )
- switch to `<input type="date">` (actually happened in 3.3, compare https://github.com/redmine/redmine/blob/3.2-stable/app/views/timelog/_form.html.erb#L20 and https://github.com/redmine/redmine/blob/3.4-stable/app/views/timelog/_form.html.erb#L19 )