### PR TITLE
Specify exact Rails version in migration

### DIFF
--- a/db/migrate/002_create_enum_prices.rb
+++ b/db/migrate/002_create_enum_prices.rb
@@ -1,4 +1,4 @@
-class CreateEnumPrices < ActiveRecord::Migration
+class CreateEnumPrices < (Rails.version < '5.1') ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     create_table :prices do |t|
       t.references :enumerations


### PR DESCRIPTION
It is not possible to migrate the plugin without specifying a migration version.