### PR TITLE
Avoid cookie session overflow

### DIFF
--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -203,8 +203,9 @@ class Timesheet
       end
     end
 
-    user_scope.select {|user|
-      user.allowed_to?(:log_time, nil, :global => true)
+    # faster alternative that avoids loading roles for each user
+    user_scope.eager_load(members: :roles).select { |u|
+      u.members.any? { |m| m.roles.any? { |r| r.permissions.include?(:log_time) } }
     }
   end
 

--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -193,13 +193,13 @@ class Timesheet
       if User.current.allowed_to?(:see_all_project_timesheets, nil, :global => true)
         user_scope = User.all
       else
-        user_scope = [User.current]
+        user_scope = User.where(id: User.current.id)
       end
     else
       if User.current.allowed_to?(:see_all_project_timesheets, nil, :global => true)
         user_scope = User.active
       else
-        user_scope = [User.current]
+        user_scope = User.where(id: User.current.id)
       end
     end
 
@@ -283,7 +283,7 @@ class Timesheet
       end
       if self.projects.present?
         condition_str << "#{TimeEntry.table_name}.project_id IN (?)"
-        condition_params << self.projects
+        condition_params << self.projects.pluck(:id)
       end
       if self.activities.present?
         condition_str << "activity_id IN (?)"


### PR DESCRIPTION
This PR fixes excessive storage usage in a session that could produce `CookieOverflow` exception.

The current implementation takes linear space to include project and user ids. The patch avoids storing all users and projects, so only constant space is required. Also, only the hash of params is marshalled instead of the `ActiveController::Parameters` object which cuts spaces by a third.

Fixes #70