### PR TITLE
Replace i18n label_all_time in Redmine 4.1

### DIFF
--- a/app/helpers/timesheet_helper.rb
+++ b/app/helpers/timesheet_helper.rb
@@ -110,7 +110,7 @@ module TimesheetHelper
   end
   
   def options_for_period_select(value)
-    options_for_select([[l(:label_all_time), 'all'],
+    options_for_select([[l(:label_total_time), 'all'],
                         [l(:label_today), 'today'],
                         [l(:label_yesterday), 'yesterday'],
                         [l(:label_this_week), 'current_week'],


### PR DESCRIPTION
Label `label_all_time` is replaced with `label_total_time` since Redmine 4.1. 

See https://redmine.org/issues/30466