### PR TITLE
Add setting to prefer group filter to user filter

### DIFF
--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -61,6 +61,11 @@ class Timesheet
       unless options[:groups].nil?
         self.groups= options[:groups].collect { |g| g.to_i }
         groups = Group.where(:id => self.groups)
+        # This new flag (off by default) clear users list before applying group filter
+        # so the group filter does not depend on the user filter
+        if Setting.plugin_redmine_timesheet_plugin['group_override']
+          self.users = []
+        end
         groups.each do |group|
           self.users += group.user_ids
         end

--- a/app/views/settings/_timesheet_settings.html.erb
+++ b/app/views/settings/_timesheet_settings.html.erb
@@ -3,6 +3,11 @@
 <p><label for="settings_precision">Number precision</label><%= text_field_tag 'settings[precision]', @settings['precision'] %></p>
 
 <p>
+  <label for="settings_group_override"><%= l(:label_group_override) %></label>
+  <%= check_box_tag 'settings[group_override]', 1, ('1'==@settings['group_override']) %>
+</p>
+
+<p>
   <label for="settings_project_status"><%= l(:label_show_project_status) %></label>
   <%= select_tag('settings[project_status]',
                  options_for_select({

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   text_active_projects: "Active"
   text_all_projects: "All (active and archived)"
   label_user_status: "Show users with the status of"
+  label_group_override: "Group filter overrides user filter"
   text_active_users: "Active only"
   text_all_users: "All"
   timesheet_groups_label: Groups

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -14,5 +14,6 @@ ru:
   text_all_projects: "Все (активные и заархивированные)"
   label_user_status: "Показывать пользователей со статусом"
   text_active_users: "Только активные"
+  label_group_override: "Фильтр групп приоритетнее, чем фильтр пользователей"
   text_all_users: "Все"
   timesheet_groups_label: Группы

--- a/init.rb
+++ b/init.rb
@@ -47,7 +47,8 @@ unless Redmine::Plugin.registered_plugins.keys.include?(:redmine_timesheet_plugi
                'list_size' => '5',
                'precision' => '2',
                'project_status' => 'active',
-               'user_status' => 'active'
+               'user_status' => 'active',
+               'settings_group_override' => false
              }, :partial => 'settings/timesheet_settings')
 
     permission :see_project_timesheets, { }, :require => :member


### PR DESCRIPTION
New feature (disabled by default for compatibility).

Enabling this setting prefers group filter selection to user filter selection. So you can choose all users from a group just by selecting it in the group filter. The original behaviour is to _add_ users from selected groups to the user list.